### PR TITLE
Handle missing variant_id in webhook

### DIFF
--- a/src/webhooks/orders.js
+++ b/src/webhooks/orders.js
@@ -46,6 +46,11 @@ router.post(
         }
         const { id: line_item_id, variant_id, quantity: ordered_qty } = item;
 
+        if (!variant_id) {
+          console.warn(`Skipping line item ${line_item_id} on order ${order.name} due to missing variant_id`);
+          continue;
+        }
+
         const productTitle = item.title;
         const productSku   = item.sku || item.barcode || null;
 


### PR DESCRIPTION
## Summary
- skip processing line items that do not provide a `variant_id`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854b90e34008333a77f88b08def41f2